### PR TITLE
Implement batch mode

### DIFF
--- a/README.build
+++ b/README.build
@@ -135,3 +135,20 @@ files that are already there... which means that you can probably
 ignore this error.  Try activating the virtualenv and running
 mfp.  If it launches, you are good to go. 
 
+RUNNING TESTS
+--------------------------
+
+There are some tests, though not as many as I would like.  What's
+there basically comes in three flavors, all of which can be run
+with various incantations of the `nosetests` test runner:  
+
+ * Python test cases in mfp/test: run with plain `nosetests` 
+
+ * C test cases in mfpdsp/test_*: run with the `testext` plugin
+   to nosetests, `python /usr/bin/nosetests --with-testext --exe` 
+
+ * end-to-end MFP patch tests, not run unless you point to them 
+   specifically: `python /usr/bin/nosetests -m e2e -w mfp/test`
+
+
+

--- a/README.build
+++ b/README.build
@@ -142,10 +142,10 @@ There are some tests, though not as many as I would like.  What's
 there basically comes in three flavors, all of which can be run
 with various incantations of the `nosetests` test runner:  
 
- * Python test cases in mfp/test: run with plain `nosetests` 
+ * Python test cases in mfp/test: run with plain `python /usr/bin/nosetests mfp/` 
 
  * C test cases in mfpdsp/test_*: run with the `testext` plugin
-   to nosetests, `python /usr/bin/nosetests --with-testext --exe` 
+   to nosetests, `python /usr/bin/nosetests --with-testext --exe`
 
  * end-to-end MFP patch tests, not run unless you point to them 
    specifically: `python /usr/bin/nosetests -m e2e -w mfp/test`

--- a/mfp/builtins/pyfunc.py
+++ b/mfp/builtins/pyfunc.py
@@ -146,7 +146,7 @@ class PyEval(Processor):
         if isinstance(self.inlets[0], MethodCall):
             self.inlets[0].call(self)
         else:
-            self.outlets[0] = self.patch.eval(self.inlets[0], self.bindings)
+            self.outlets[0] = self.patch.parse_obj(self.inlets[0], **self.bindings)
 
     def clear(self):
         self.bindings = {}

--- a/mfp/gui/colordb.py
+++ b/mfp/gui/colordb.py
@@ -6,8 +6,6 @@ Copyright (c) 2013 Bill Gribble <grib@billgribble.com>
 '''
 
 from ..singleton import Singleton
-from gi.repository import Clutter 
-
 
 class RGBAColor(object):
     def __init__(self, r, g, b, a):
@@ -29,6 +27,7 @@ class ColorDB (Singleton):
     rgba_colors = {}  
 
     def find(self, *colorinfo):
+        from gi.repository import Clutter 
         ll = len(colorinfo)
         if ll > 2:
             # RGB or RGBA color values 

--- a/mfp/log.py
+++ b/mfp/log.py
@@ -6,6 +6,7 @@ log_time_base = datetime.now()
 log_module = "main"
 
 log_file = sys.stdout
+log_raw = False 
 log_func = None
 log_debug = True
 log_force_console = False 
@@ -14,8 +15,12 @@ ts_trans = string.maketrans("0123456789", "xxxxxxxxxx")
 
 def make_log_entry(tag, *parts):
     global log_time_base
+    global log_raw 
 
     msg = ' '.join([str(p) for p in parts])
+    if log_raw: 
+        return msg + '\n'
+
     dt = (datetime.now() - log_time_base).total_seconds()
     ts = "%.3f" % dt
     leader = "[%8s %6s]" % (ts, tag)

--- a/mfp/log.py
+++ b/mfp/log.py
@@ -6,6 +6,7 @@ log_time_base = datetime.now()
 log_module = "main"
 
 log_file = sys.stdout
+log_quiet = False
 log_raw = False 
 log_func = None
 log_debug = True
@@ -16,10 +17,14 @@ ts_trans = string.maketrans("0123456789", "xxxxxxxxxx")
 def make_log_entry(tag, *parts):
     global log_time_base
     global log_raw 
+    global log_quiet
 
     msg = ' '.join([str(p) for p in parts])
-    if log_raw: 
-        return msg + '\n'
+    if log_raw:
+        if (not log_quiet or tag == "print"): 
+            return msg + '\n'
+        else: 
+            return None
 
     dt = (datetime.now() - log_time_base).total_seconds()
     ts = "%.3f" % dt
@@ -37,17 +42,18 @@ def write_log_entry(msg, level=0):
     global log_func
 
     logged = False 
-    if log_func:
+    if msg and log_func:
         log_func(msg, level)
         logged = True 
 
-    if log_file and ((not logged) or log_force_console):
+    if log_file and msg and ((not logged) or log_force_console):
         log_file.write(msg)
 
 def rpclog(msg, level):
     levels = { 0: "DEBUG", 1: "WARNING", 2: "ERROR", 3: "FATAL" }
-    print "[LOG] %s: %s" % (levels.get(level, "DEBUG"), msg)
-    sys.stdout.flush()
+    if msg:
+        print "[LOG] %s: %s" % (levels.get(level, "DEBUG"), msg)
+        sys.stdout.flush()
 
 def error(* parts, **kwargs):
     global log_module

--- a/mfp/mfp_app.py
+++ b/mfp/mfp_app.py
@@ -156,6 +156,7 @@ class MFPApp (Singleton):
         # configure logging
         log.log_raw = True 
         log.log_debug = False
+        log.log_force_console = False
 
         self.open_file(None)
         p = self.patches.get('default')

--- a/mfp/mfp_main.py
+++ b/mfp/mfp_main.py
@@ -255,13 +255,15 @@ def main():
     else: 
         patchfiles = args.get("patchfile")
         if app.batch_mode: 
-            if len(patchfiles) == 1:
-                app.batch_obj = patchfiles[0]
-                app.exec_batch()
+            try: 
+                if len(patchfiles) == 1:
+                    app.batch_obj = patchfiles[0]
+                    app.exec_batch()
+                else:
+                    log.debug("Batch mode requires exactly one input file")
+            finally:
                 app.finish()
-            else:
-                log.debug("Batch mode requires exactly one input file")
-                app.finish()
+
         else:
             # create initial patch
             if len(patchfiles): 

--- a/mfp/mfp_main.py
+++ b/mfp/mfp_main.py
@@ -75,6 +75,10 @@ def exit_sighandler(signum, frame):
 
 def test_imports(): 
     try: 
+        import gi 
+        gi.require_version('Gtk', '3.0')
+        gi.require_version('GtkClutter', '1.0')
+        gi.require_version('Clutter', '1.0')
         import simplejson
         import numpy 
         import nose 

--- a/mfp/mfp_main.py
+++ b/mfp/mfp_main.py
@@ -134,12 +134,17 @@ def main():
                         help="Path to create Unix-domain socket for RPC")
     parser.add_argument("-d", "--debug", action="store_true", 
                         help="Enable debugging behaviors")
+
+    # batch mode options
     parser.add_argument("-b", "--batch", action="store_true",
                         help="Run in batch mode")
     parser.add_argument("-a", "--args", default='', 
                         help="Batch mode patch arguments")
     parser.add_argument("-I", "--batch-input", default=None, 
                         help="Batch mode input file")
+    parser.add_argument("-e", "--batch-eval", action="store_true",
+                        help="Call eval() on input before sending")
+
     args = vars(parser.parse_args())
 
     # test imports to make sure everything is installed properly 
@@ -167,8 +172,10 @@ def main():
         app.batch_mode = True 
         app.batch_args = args.get("args")
         app.batch_input_file = args.get("batch_input")
+        app.batch_eval = args.get("batch_eval", False)
         app.no_gui = True 
-        log.debug("Starting in batch mode")
+        log.log_raw = True
+        log.log_quiet = True 
 
     if args.get("verbose"):
         log.log_force_console = True 
@@ -247,6 +254,7 @@ def main():
             if len(patchfiles) == 1:
                 app.batch_obj = patchfiles[0]
                 app.exec_batch()
+                app.finish()
             else:
                 log.debug("Batch mode requires exactly one input file")
                 app.finish()

--- a/mfp/test/e2e.py
+++ b/mfp/test/e2e.py
@@ -1,0 +1,24 @@
+
+
+from unittest import TestCase 
+from subprocess import Popen, PIPE
+
+class e2eIntegration(TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def get_output(self, objname, inputs):
+        pout, perr = Popen(['mfp', '-b', '-e', objname], 
+                           stdin=PIPE, stdout=PIPE).communicate(inputs)
+        return pout.split('\n')[:-1]
+
+    def e2e_echo(self):
+        out = self.get_output("echo", '1\n2\n3')
+        self.assertEqual(out, ['1', '2', '3'])
+
+
+
+

--- a/mfp/test/echo.mfp
+++ b/mfp/test/echo.mfp
@@ -1,0 +1,91 @@
+{
+    "gui_params": {
+        "display_type": "patch",
+        "height": 20,
+        "initargs": "",
+        "layers": [
+            [
+                "Layer 0",
+                "__patch__"
+            ]
+        ],
+        "name": "echo",
+        "num_inlets": 1,
+        "num_outlets": 1,
+        "obj_id": 0,
+        "scope": "__app__",
+        "top_level": true,
+        "width": 0
+    },
+    "hot_inlets": [
+        0
+    ],
+    "objects": {
+        "1": {
+            "connections": [
+                [
+                    [
+                        5,
+                        0
+                    ]
+                ]
+            ],
+            "do_onload": false,
+            "gui_params": {
+                "display_type": "processor",
+                "height": 25.0,
+                "is_export": false,
+                "layername": "Layer 0",
+                "no_export": false,
+                "position_x": 153.2911376953125,
+                "position_y": 128.2281494140625,
+                "scope": "__patch__",
+                "show_label": true,
+                "update_required": false,
+                "width": 60.0
+            },
+            "initargs": "0",
+            "midi_filters": null,
+            "midi_mode": null,
+            "name": "processor_001",
+            "osc_methods": [],
+            "properties": {},
+            "type": "inlet"
+        },
+        "5": {
+            "connections": [
+                []
+            ],
+            "do_onload": false,
+            "gui_params": {
+                "display_type": "processor",
+                "height": 25.0,
+                "is_export": false,
+                "layername": "Layer 0",
+                "no_export": false,
+                "position_x": 153.2911376953125,
+                "position_y": 224.2281494140625,
+                "scope": "__patch__",
+                "show_label": true,
+                "update_required": false,
+                "width": 71.0
+            },
+            "initargs": "0",
+            "midi_filters": null,
+            "midi_mode": null,
+            "name": "processor_005",
+            "osc_methods": [],
+            "properties": {},
+            "type": "outlet"
+        }
+    },
+    "scopes": {
+        "__patch__": {
+            "patch": 0,
+            "processor_001": 1,
+            "processor_005": 5,
+            "self": 0
+        }
+    },
+    "type": "echo"
+}


### PR DESCRIPTION
In support of some of the "Porting" tickets (#150, #250) this adds a batch mode to allow end-to-end tests to be run through the full running MFP app.  

As a side effect, this also enables patches to be used from the command line.  Startup time is slow enough that this is probably not a really useful thing for most purposes, but it's there. 

Still to do: 
 * Error handling during batch mode setup. 
 * Time-based termination options 
 