### PR TITLE
Don't time out on loading big patches

### DIFF
--- a/mfp/builtins/loadbang.py
+++ b/mfp/builtins/loadbang.py
@@ -8,6 +8,7 @@ Copyright (c) 2013 Bill Gribble <grib@billgribble.com>
 from ..processor import Processor 
 from ..bang import Bang, Uninit 
 from ..mfp_app import MFPApp
+from mfp import log
 
 class LoadBang (Processor):
     doc_tooltip_obj = "Emit a Bang message on patch load"

--- a/mfp/builtins/sendrcv.py
+++ b/mfp/builtins/sendrcv.py
@@ -71,7 +71,6 @@ class Send (Processor):
                 if objid != self.dest_obj.obj_id:
                     pruned.append([objid, port])
             conns[0] = pruned
-            
         return prms
 
     def connect(self, outlet, target, inlet, show_gui=True):
@@ -288,7 +287,8 @@ class Recv (Processor):
 
     def _wait_connect(self):
         def recv_recheck():
-            return self._connect(self.src_name, self.src_outlet, False)
+            conn = self._connect(self.src_name, self.src_outlet, False)
+            return conn
         Recv.task_nibbler.add_task(recv_recheck, True)
 
     def _connect(self, src_name, src_outlet, wait=True):
@@ -297,10 +297,11 @@ class Recv (Processor):
             self.src_obj = src_obj
             self.src_obj.connect(self.src_outlet, self, 0, False)
             return True 
-        else: 
-            if wait:
-                self._wait_connect()
-            return False 
+        elif wait:
+            self._wait_connect()
+
+        parent = self.patch.name if self.patch else '(top)'
+        return False 
 
     def trigger(self):
         if self.inlets[1] is not Uninit:

--- a/mfp/gui/patch_element.py
+++ b/mfp/gui/patch_element.py
@@ -172,7 +172,7 @@ class PatchElement (Clutter.Group):
 
         for c in self.connections_in:
             c.draw()
-    
+
     def move_z (self, z):
         self.position_z = z
         self.set_z_position(z)
@@ -475,7 +475,9 @@ class PatchElement (Clutter.Group):
         Clutter.Group.set_size(self, self.width, self.height)
         self.update_badge()
         self.draw_ports()
-        self.send_params()
+
+        if self.obj_id and self.name:
+            self.send_params()
 
     def configure(self, params):
         self.num_inlets = params.get("num_inlets", 0)
@@ -513,6 +515,12 @@ class PatchElement (Clutter.Group):
 
         w = params.get("width") or w_orig
         h = params.get("height") or h_orig
+
+        if "position_x" in params and "position_y" in params:
+            xpos = params['position_x']
+            ypos = params['position_y']
+
+            self.move(xpos, ypos)
 
         if "z_index" in params:
             self.move_z(params.get("z_index"))

--- a/mfp/gui/patch_element.py
+++ b/mfp/gui/patch_element.py
@@ -408,20 +408,20 @@ class PatchElement (Clutter.Group):
 
             if pobj is None:
                 pobj = Clutter.Rectangle()
-                if dsp_port:
-                    pobj.set_border_width(1.5)
                 pobj.set_size(self.get_style('porthole_width'),
                               self.get_style('porthole_height'))
                 self.add_actor(pobj)
                 self.port_elements[pid] = pobj
 
             if dsp_port:
+                pobj.set_border_width(1.5)
                 pobj.set_color(self.stage.color_bg)
                 pobj.set_border_color(self.get_color('stroke-color'))
             else:
                 pobj.set_color(self.get_color('stroke-color'))
 
             pobj.set_position(px, py)
+            pobj.set_z_position(0.2)
             pobj.show()
             ports_done.append(pobj)
 

--- a/mfp/gui/patch_window.py
+++ b/mfp/gui/patch_window.py
@@ -412,8 +412,7 @@ class PatchWindow(object):
             import traceback
             log.warning("add_element: Error while creating with factory", factory)
             log.warning(e)
-            for l in traceback.format_exc().split("\n"):
-                log.debug(l)
+            log.debug_traceback()
             return True
 
         self.active_layer().add(b)

--- a/mfp/gui/processor_element.py
+++ b/mfp/gui/processor_element.py
@@ -212,4 +212,5 @@ class ProcessorElement (PatchElement):
 
         params["width"] = max(self.width, params.get("export_w") or 0)
         params["height"] = max(self.height, (params.get("export_h") or 0) + labelheight)
+
         PatchElement.configure(self, params)

--- a/mfp/gui/processor_element.py
+++ b/mfp/gui/processor_element.py
@@ -123,7 +123,7 @@ class ProcessorElement (PatchElement):
         self.update()
 
     def label_edit_finish(self, widget, text=None):
-        if text is not None and text != self.label_text:
+        if text is not None:
             parts = text.split(' ', 1)
             obj_type = parts[0]
             if len(parts) > 1:
@@ -146,7 +146,10 @@ class ProcessorElement (PatchElement):
         self.update()
 
     def label_changed_cb(self, *args):
-        self.update()
+        newtext = self.label.get_text()
+        if newtext != self.label_text:
+            self.label_text = newtext
+            self.update()
 
     def set_size(self, w, h):
         PatchElement.set_size(self, w, h)
@@ -193,24 +196,24 @@ class ProcessorElement (PatchElement):
                 else:
                     self.remove_actor(self.label)
 
-        if "export_w" in params and "export_h" in params:
-            self.export_x = params.get("export_x")
-            self.export_y = params.get("export_y")
-            self.export_w = params.get("export_w")
-            self.export_h = params.get("export_h")
-            if self.export_x is not None and self.export_y is not None:
-                self.export_created = True
-
-        if self.obj_id is not None and self.obj_state != self.OBJ_COMPLETE:
-            self.obj_state = self.OBJ_COMPLETE
-            if self.export_created:
-                MFPGUI().mfp.create_export_gui(self.obj_id)
-            need_update = True
-
-        if need_update:
-            self.update()
+        self.export_x = params.get("export_x")
+        self.export_y = params.get("export_y")
+        self.export_w = params.get("export_w")
+        self.export_h = params.get("export_h")
+        if self.export_x is not None and self.export_y is not None:
+            self.export_created = True
 
         params["width"] = max(self.width, params.get("export_w") or 0)
         params["height"] = max(self.height, (params.get("export_h") or 0) + labelheight)
 
         PatchElement.configure(self, params)
+
+        if self.obj_id is not None and self.obj_state != self.OBJ_COMPLETE:
+            self.obj_state = self.OBJ_COMPLETE
+            if self.export_created:
+                MFPGUI().mfp.create_export_gui(self.obj_id)
+                need_update = True
+
+        if need_update:
+            self.update()
+

--- a/mfp/gui_command.py
+++ b/mfp/gui_command.py
@@ -1,4 +1,3 @@
-
 from .rpc import RPCWrapper, rpcwrap, rpcwrap_noresp
 
 class GUICommand (RPCWrapper):

--- a/mfp/gui_command.py
+++ b/mfp/gui_command.py
@@ -132,6 +132,9 @@ class GUICommand (RPCWrapper):
                     o.container = layer.group
                 elif isinstance(parent, PatchElement): 
                     # FIXME: don't hardcode GOP offsets 
+                    if not parent.export_x:
+                        log.debug("_create: parent %s.%s has no export_x"
+                                  % (parent.scope.name, parent,name))
                     xpos = params.get("position_x", 0) - parent.export_x + 2
                     ypos = params.get("position_y", 0) - parent.export_y + 20
                     o.move(xpos, ypos)

--- a/mfp/gui_main.py
+++ b/mfp/gui_main.py
@@ -98,10 +98,9 @@ class MFPGUI (Singleton):
             # direct logging to GUI log console
             Gtk.main()
         except Exception, e:
+            log.error("Caught GUI exception:", e)
             log.debug_traceback()
-            for l in traceback.format_exc().split("\n"):
-                print "[LOG] ERROR:", l
-                sys.stdout.flush()
+            sys.stdout.flush()
 
     def finish(self):
         from gi.repository import Gtk

--- a/mfp/method.py
+++ b/mfp/method.py
@@ -39,16 +39,17 @@ class MethodCall(object):
         if callable(m):
             try:
                 return m(*self.args, **self.kwargs)
-            except Exception, e:
-                print "Error calling", self.method, "on", target
-                print "args=%s, kwargs=%s" % (self.args, self.kwargs)
-                raise MethodCallError("Method '%s' for type '%s' raised exception %s"
-                                      % (self.method, target.init_type, e))
+            except Exception as e:
+                log.debug("Error calling", self.method, "on", target)
+                log.debug( "args=%s, kwargs=%s" % (self.args, self.kwargs))
+                log.debug_traceback()
+                raise MethodCallError("Method '%s' for type '%s' raised exception '%s' %s"
+                                      % (self.method, target.init_type, e, type(e)))
         elif self.fallback:
             try:
                 return self.fallback([self] + self.args, **self.kwargs)
-            except Exception, e:
-                raise MethodCallError("Method '%s' for type '%s' raised exception %s"
+            except Exception as e:
+                raise MethodCallError("Method fallback '%s' for type '%s' raised exception '%s'"
                                       % (self.method, target.init_type, e))
         else:
             log.debug("MethodCall.call():", target, self.method, m, type(m))

--- a/mfp/mfp_app.py
+++ b/mfp/mfp_app.py
@@ -391,8 +391,7 @@ class MFPApp (Singleton):
             log.error("Caught exception while trying to create %s (%s)"
                       % (init_type, init_args))
             log.debug(e)
-            import traceback
-            traceback.print_exc()
+            log.debug_traceback()
             self.cleanup()
             return None
 

--- a/mfp/mfp_command.py
+++ b/mfp/mfp_command.py
@@ -97,6 +97,7 @@ class MFPCommand(RPCWrapper):
     def set_params(self, obj_id, params):
         from .mfp_app import MFPApp
         obj = MFPApp().recall(obj_id)
+
         if isinstance(obj, Processor):
             obj.gui_params = params
 

--- a/mfp/patch.py
+++ b/mfp/patch.py
@@ -438,12 +438,13 @@ class Patch(Processor):
                     log.debug_traceback()
 
         self.update_export_bounds()
+
         if self.gui_created:
             MFPApp().gui_command.configure(self.obj_id, self.gui_params)
 
         if MFPApp().gui_command:
             MFPApp().gui_command.load_complete()
-            return True
+        return True
 
     def obj_is_exportable(self, obj):
         if (obj.gui_params.get('is_export') 

--- a/mfp/patch_clonescope.py
+++ b/mfp/patch_clonescope.py
@@ -149,5 +149,11 @@ def clonescope(self, scopename, num_copies, **kwargs):
     if self.gui_created:
         MFPApp().gui_command.configure(self.obj_id, self.gui_params)
 
+    if not MFPApp().no_onload:
+        self.task_nibbler.add_task(
+            lambda (objects): self._run_onload(objects), False,
+            [obj for obj in all_clones]
+        )
+
     for obj in need_gui:
         obj.create_gui()

--- a/mfp/patch_clonescope.py
+++ b/mfp/patch_clonescope.py
@@ -138,7 +138,6 @@ def clonescope(self, scopename, num_copies, **kwargs):
                     if (tobj_newid, tport) not in newobj.connections_out[port_num]:
                         newobj.connect(port_num, tobj_newid, tport)
 
-
     for name, srcobj in ui_items.items():
         # kludge -- change labels in the UI template objects
         if srcobj.gui_params.get("display_type") == "text":
@@ -152,9 +151,3 @@ def clonescope(self, scopename, num_copies, **kwargs):
 
     for obj in need_gui:
         obj.create_gui()
-
-    # make sure [loadbang] get triggered
-    if not MFPApp().no_onload:
-        self.task_nibbler.add_task(
-            lambda (newobjs): self._run_onload(newobjs), False,
-            [obj for obj in all_clones])

--- a/mfp/patch_json.py
+++ b/mfp/patch_json.py
@@ -113,11 +113,13 @@ def json_unpack_connections(self, data, idmap):
                     srcobj.connect(outlet, dstobj, inlet)
 
 @extends(Patch)
-def json_unpack_objects(self, data, scope, create_gui=True):
+def json_unpack_objects(self, data, scope):
     from .mfp_app import MFPApp
     idmap = {}
     idlist = data.get('objects').keys()
     idlist.sort(key=lambda x: int(x))
+    need_gui = []
+
     for oid in idlist:
         prms = data.get('objects')[oid]
 
@@ -128,8 +130,8 @@ def json_unpack_objects(self, data, scope, create_gui=True):
         newobj = MFPApp().create(otype, oargs, self, scope, oname)
         newobj.patch = self
         newobj.load(prms)
-        if create_gui and self.gui_created:
-            newobj.create_gui()
+        if self.gui_created:
+            need_gui.append(newobj)
 
         idmap[int(oid)] = newobj
 
@@ -137,6 +139,10 @@ def json_unpack_objects(self, data, scope, create_gui=True):
     defscope = data.get('scopes').get('__patch__')
     selfid = int(defscope.get("self") or "0")
     idmap[selfid] = self
+
+    self.update_export_bounds()
+    for obj in need_gui:
+        obj.create_gui()
 
     return idmap
 

--- a/mfp/patch_json.py
+++ b/mfp/patch_json.py
@@ -113,7 +113,7 @@ def json_unpack_connections(self, data, idmap):
                     srcobj.connect(outlet, dstobj, inlet)
 
 @extends(Patch)
-def json_unpack_objects(self, data, scope):
+def json_unpack_objects(self, data, scope, create_gui=True):
     from .mfp_app import MFPApp
     idmap = {}
     idlist = data.get('objects').keys()
@@ -128,7 +128,7 @@ def json_unpack_objects(self, data, scope):
         newobj = MFPApp().create(otype, oargs, self, scope, oname)
         newobj.patch = self
         newobj.load(prms)
-        if self.gui_created:
+        if create_gui and self.gui_created:
             newobj.create_gui()
 
         idmap[int(oid)] = newobj

--- a/mfp/processor.py
+++ b/mfp/processor.py
@@ -722,15 +722,22 @@ class Processor (object):
     def create_gui(self, **kwargs):
         from .mfp_app import MFPApp
         parent_id = self.patch.obj_id if self.patch is not None else None
+        for param, value in kwargs.items():
+            self.gui_params[param] = value
+
+        if 'is_export' in kwargs: 
+            self.gui_params['position_x'] += (
+                self.patch.gui_params.get('export_frame_xoff', 2) 
+                - (self.patch.gui_params.get('export_x') or 0)
+            )
+            self.gui_params['position_y'] += (
+                self.gui_params.get('export_frame_yoff', 20)
+                - (self.patch.gui_params.get('export_y') or 0)
+            )
+
         MFPApp().gui_command.create(self.init_type, self.init_args, self.obj_id,
                                     parent_id, self.gui_params)
         self.gui_created = True
-        need_update = False
-        for param, value in kwargs.items():
-            self.gui_params[param] = value
-            need_update = True
-        if need_update:
-            MFPApp().gui_command.configure(self.obj_id, self.gui_params)
 
     def delete_gui(self):
         from .mfp_app import MFPApp
@@ -777,7 +784,9 @@ class Processor (object):
 
     def clone(self, patch, scope, name):
         from .mfp_app import MFPApp
+        from .patch import Patch
         prms = self.save()
+
         newobj = MFPApp().create(prms.get("type"), prms.get("initargs"),
                                  patch, scope, name)
         newobj.load(prms)

--- a/mfp/processor.py
+++ b/mfp/processor.py
@@ -725,15 +725,21 @@ class Processor (object):
         for param, value in kwargs.items():
             self.gui_params[param] = value
 
-        if 'is_export' in kwargs: 
-            self.gui_params['position_x'] += (
-                self.patch.gui_params.get('export_frame_xoff', 2) 
+        if kwargs.get('is_export'):
+            xoff = (
+                self.patch.gui_params.get('export_frame_xoff', 2)
                 - (self.patch.gui_params.get('export_x') or 0)
             )
-            self.gui_params['position_y'] += (
+
+            self.gui_params['export_offset_x'] = xoff
+            self.gui_params['position_x'] += xoff
+            yoff = (
                 self.gui_params.get('export_frame_yoff', 20)
                 - (self.patch.gui_params.get('export_y') or 0)
             )
+
+            self.gui_params['export_offset_y'] = yoff
+            self.gui_params['position_y'] += yoff
 
         MFPApp().gui_command.create(self.init_type, self.init_args, self.obj_id,
                                     parent_id, self.gui_params)

--- a/mfp/rpc/rpc_wrapper.py
+++ b/mfp/rpc/rpc_wrapper.py
@@ -101,7 +101,9 @@ class RPCWrapper (object):
         try: 
             self.rpchost.put(r, self.peer_id)
         except Exception as e: 
-            log.debug("[call_remotely] Error in RPC operation:", e)
+            if self.rpchost:
+                log.debug("[call_remotely] Error in RPC operation:", e)
+                log.debug_traceback()
             return None 
 
         puttime = str(datetime.now())

--- a/mfp/rpc/worker_pool.py
+++ b/mfp/rpc/worker_pool.py
@@ -19,8 +19,6 @@ class BaseWorker (object):
         self.pool = pool
         self.thunk = thunk
         self.quit_req = False
-        #self.lock = threading.Lock()
-        #self.condition = threading.Condition(self.lock)
         self.thread = threading.Thread(target=self._thread_func)
         self.thread.start()
 


### PR DESCRIPTION
Big patches involving dynamically created objects (like `[mix8bus]` from https://github.com/bgribble/mfp-patches) usually time out.  The cloning and GUI creation are all done "inline" with the initial request. 

This branch refactors the creation process to allow the `[loadbang]` driven bits, which is all the dynamic patch programming (via `@clonescope`), to happen after the successful return of the intial request.   This change surfaced a lot of race conditions and impliit timing dependencies that weren't an issue when everything was synchronous. Surprise!  

Now loading `[mix8bus 16]`, which was impossible before, works successfully (though there are some other bugs with creating that big of a patch, I think a different race in creating DSP objects, but I'll look into that in another PR). 
