### PR TITLE
Add C-. force-reset to unselect all and remove all mod keys

### DIFF
--- a/mfp/gui/app_window.py
+++ b/mfp/gui/app_window.py
@@ -133,9 +133,7 @@ class AppWindow (SignalMixin):
 
         return self.selected_layer
 
-    def active_group(self):
-        return self.active_layer().group
-
+    # FIXME Clutter 
     def ready(self):
         if self.window and self.window.get_realized():
             return True
@@ -206,7 +204,6 @@ class AppWindow (SignalMixin):
         self.register(b)
         self.refresh(b)
         await self.select(b)
-
         await b.begin_edit()
         return True
 

--- a/mfp/gui/app_window_views.py
+++ b/mfp/gui/app_window_views.py
@@ -46,7 +46,7 @@ def init_object_view(self):
         else:
             parent = (self.selected_patch,)
 
-        self.object_view.update(obj, parent)
+        self.signal_emit("rename", obj, parent)
 
     async def obj_selected(obj):
         await self._select(obj)

--- a/mfp/gui/clutter/app_window.py
+++ b/mfp/gui/clutter/app_window.py
@@ -164,7 +164,11 @@ class ClutterAppWindowBackend (AppWindowBackend):
                     (element.layer.scope, element.layer.patch),
                 )
 
+        def on_rename(window, signal, obj, parent):
+            object_view.update(obj, parent)
+
         self.wrapper.signal_listen("created", on_create)
+        self.wrapper.signal_listen("rename", on_rename)
 
         return object_view
 

--- a/mfp/gui/clutter/processor_element.py
+++ b/mfp/gui/clutter/processor_element.py
@@ -3,11 +3,11 @@ clutter/processor_element.py -- clutter backend for processor elements
 
 Copyright (c) Bill Gribble <grib@billgribble.com>
 """
-import math
 
 from gi.repository import Clutter
 import cairo
 
+from mfp import log
 from ..colordb import ColorDB
 from .base_element import ClutterBaseElementBackend
 from ..processor_element import (

--- a/mfp/gui/input_manager.py
+++ b/mfp/gui/input_manager.py
@@ -91,6 +91,9 @@ class InputManager (object):
             mode.enable()
 
     def disable_minor_mode(self, mode):
+        if mode not in self.minor_modes:
+            return
+
         cb = mode.disable()
         if inspect.isawaitable(cb):
             MFPGUI().async_task(cb)

--- a/mfp/gui/mfp.glade
+++ b/mfp/gui/mfp.glade
@@ -5,6 +5,8 @@
   <object class="GtkWindow" id="main_window">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">MFP</property>
+    <property name="width_request">1000</property>
+    <property name="height_request">800</property>
     <property name="default_width">1000</property>
     <property name="default_height">800</property>
     <child>

--- a/mfp/gui/modes/global_mode.py
+++ b/mfp/gui/modes/global_mode.py
@@ -84,6 +84,10 @@ class GlobalMode (InputMode):
         self.bind("HOVER", lambda: self.hover(False))
         self.bind("S-HOVER", lambda: self.hover(True))
 
+        self.bind('C-.', self.force_reset, "Reset all modifier keys and input modes")
+        self.bind('S-C-.', self.force_reset, "Reset all modifier keys and input modes")
+        self.bind('M1-C-.', self.force_reset, "Reset all modifier keys and input modes")
+
     def inspect(self):
         from flopsy import Store
         Store.show_inspector(event_loop=MFPGUI().async_task.asyncio_loop)
@@ -121,6 +125,15 @@ class GlobalMode (InputMode):
         oldpos = self.window.backend.content_console_pane.get_position()
         self.window.backend.content_console_pane.set_position(oldpos - 1)
         return False
+
+    async def force_reset(self):
+        await self.window.unselect_all()
+
+        while self.manager.minor_modes:
+            self.manager.disable_minor_mode(self.manager.minor_modes[0])
+
+        self.manager.keyseq.mouse_buttons = set()
+        self.manager.keyseq.mod_keys = set()
 
     async def transient_msg(self):
         from ..message_element import TransientMessageElement

--- a/mfp/gui/modes/label_edit.py
+++ b/mfp/gui/modes/label_edit.py
@@ -1,8 +1,8 @@
 #! /usr/bin/env python
 '''
-label_edit.py: Minor mode for editing contents of a clutter.Text label
+label_edit.py: Minor mode for editing contents of a label
 
-Copyright (c) 2010 Bill Gribble <grib@billgribble.com>
+Copyright (c) Bill Gribble <grib@billgribble.com>
 '''
 
 import asyncio
@@ -136,6 +136,7 @@ class LabelEditMode (InputMode):
     def set_selection(self, start, end):
         self.selection_start = start
         self.selection_end = end
+        self.update_label(raw=True)
         self.widget.set_selection(start, end)
 
     def delete_selection(self):
@@ -254,7 +255,6 @@ class LabelEditMode (InputMode):
 
         self.undo_stack.append((self.text, self.editpos))
         self.text = new_text
-        return True
 
         editpos = self.widget.get_cursor_position()
         if editpos == -1:
@@ -264,7 +264,7 @@ class LabelEditMode (InputMode):
         else:
             self.editpos = change_at
 
-        return
+        return True
 
     async def commit_edits(self):
         self.text = self.widget.get_text()


### PR DESCRIPTION
This is a partial mitigation for #292. At least you can now type `C-.` when clutter gets messed up. I can't get any traction on the actual root causes yet. 