### PR TITLE
Better solution for select problems

### DIFF
--- a/mfp/builtins/pyfunc.py
+++ b/mfp/builtins/pyfunc.py
@@ -555,6 +555,11 @@ def register():
         "split", "Split a string into pieces")
 
     mk_binary(
+        lambda haystack, needle: (needle in haystack),
+        "in", "Check if an item is in an iterable"
+    )
+
+    mk_binary(
         lambda inval, joinstr="": joinstr.join(inval) if isiterable(inval) else inval,
         "join", "Concatenate an array or tuple of strings into one")
 

--- a/mfp/gui/app_window.py
+++ b/mfp/gui/app_window.py
@@ -162,7 +162,6 @@ class AppWindow (SignalMixin):
 
         oldcount = self.object_counts_by_type.get(element.display_type, 0)
         self.object_counts_by_type[element.display_type] = oldcount + 1
-        self.input_mgr.event_sources[element] = element
         self.backend.register(element)
         MFPGUI().async_task(self.signal_emit("add", element))
 
@@ -177,8 +176,6 @@ class AppWindow (SignalMixin):
             element.layer.remove(element)
         if element in self.objects:
             self.objects.remove(element)
-        if element in self.input_mgr.event_sources:
-            del self.input_mgr.event_sources[element]
 
         self.backend.unregister(element)
         MFPGUI().async_task(self.signal_emit("remove", element))

--- a/mfp/gui/clutter/app_window.py
+++ b/mfp/gui/clutter/app_window.py
@@ -188,7 +188,8 @@ class ClutterAppWindowBackend (AppWindowBackend):
             self.autoplace_layer = self.wrapper.selected_layer
             self.autoplace_layer.backend.group.add_actor(self.autoplace_marker)
         elif self.autoplace_layer != self.wrapper.selected_layer:
-            self.autoplace_layer.backend.group.remove_actor(self.autoplace_marker)
+            if self.autoplace_layer.backend.group:
+                self.autoplace_layer.backend.group.remove_actor(self.autoplace_marker)
             self.autoplace_layer = self.wrapper.selected_layer
             self.autoplace_layer.backend.group.add_actor(self.autoplace_marker)
         self.autoplace_marker.set_position(x, y)
@@ -569,7 +570,12 @@ class ClutterAppWindowBackend (AppWindowBackend):
             else:
                 element.container = element.layer.backend.group
 
-        self.wrapper.event_sources[element.group] = element
+        if element.group is None:
+            log.debug(f"[register] group for {element} is None!!")
+        else:
+            self.wrapper.event_sources[element.group] = element
+            if hasattr(element, 'texture'):
+                self.wrapper.event_sources[element.texture] = element
 
         if not isinstance(element, ConnectionElement):
             if not self.wrapper.load_in_progress:
@@ -584,6 +590,8 @@ class ClutterAppWindowBackend (AppWindowBackend):
         self.object_view.remove(element)
         if element.group in self.wrapper.event_sources:
             del self.wrapper.event_sources[element.group]
+        if hasattr(element, 'texture') and element.texture in self.wrapper.event_sources:
+            del self.wrapper.event_sources[element.texture]
 
     def refresh(self, element):
         if isinstance(element, PatchDisplay):

--- a/mfp/gui/clutter/connection_element.py
+++ b/mfp/gui/clutter/connection_element.py
@@ -39,6 +39,13 @@ class ClutterConnectionElementImpl(ConnectionElement, ConnectionElementImpl, Clu
         self.move(px, py)
         self.draw()
 
+    async def delete(self):
+        if self.texture:
+            self.group.set_content(None)
+            self.texture = None
+
+        await super().delete()
+
     def redraw(self):
         super().redraw()
         self.draw()

--- a/mfp/gui/clutter/event.py
+++ b/mfp/gui/clutter/event.py
@@ -74,9 +74,23 @@ def transform_event(clutter_event, mfp_target):
             dy=delta.dy
         )
 
+    # NOTE: the event.source is not reliable, at least not on my
+    # machine with my GL setup. It sometimes comes up with a Clutter
+    # object that is not visible, or is on the other edge of the screen.
+    # enter/leave really only used for HOVER determination to show object
+    # docs so it's OK that it is wrong  sometimes :/
     if clutter_event.type == Clutter.EventType.ENTER:
         if hasattr(mfp_target, 'event_sources'):
-            source = mfp_target.event_sources.get(clutter_event.source, mfp_target)
+            source = mfp_target.event_sources.get(clutter_event.source)
+            if not source and hasattr(clutter_event.source, 'container'):
+                container = clutter_event.source.container
+                source = mfp_target.event_sources.get(container)
+                if not source and hasattr(container, 'container'):
+                    container = container.container
+                    source = mfp_target.event_sources.get(container)
+            if not source:
+                source = mfp_target
+
         else:
             source = mfp_target
         return EnterEvent(target=source)

--- a/mfp/gui/clutter/layer.py
+++ b/mfp/gui/clutter/layer.py
@@ -29,7 +29,7 @@ class ClutterLayerBackend(LayerBackend):
         else:
             child = obj
 
-        self.group.remove_actor(child)
+        self.group.remove_child(child)
 
     def add(self, obj):
         if isinstance(obj, BaseElement):
@@ -41,8 +41,8 @@ class ClutterLayerBackend(LayerBackend):
         child = group
         if parent != self.group:
             if parent:
-                parent.remove_actor(child)
-            self.group.add_actor(child)
+                parent.remove_child(child)
+            self.group.add_child(child)
 
     def delete(self):
         del self.group

--- a/mfp/gui/clutter/message_element.py
+++ b/mfp/gui/clutter/message_element.py
@@ -32,11 +32,24 @@ class ClutterMessageElementImpl(MessageElement, MessageElementImpl, ClutterBaseE
         self.group.set_reactive(True)
 
         # resize widget whne text gets longer
-        self.label.signal_listen('text-changed', self.text_changed_cb)
+        self.handler_id = self.label.signal_listen('text-changed', self.text_changed_cb)
         self.set_size(35, 25)
         self.redraw()
 
+    async def delete(self):
+        if self.texture:
+            self.group.set_content(None)
+            self.texture = None
+        if self.label:
+            self.label.signal_unlisten(self.handler_id)
+            await self.label.delete()
+            self.label = None
+
+        await super().delete()
+
     def redraw(self):
+        if not self.texture:
+            return
         super().redraw()
         self.texture.invalidate()
 
@@ -47,6 +60,8 @@ class ClutterMessageElementImpl(MessageElement, MessageElementImpl, ClutterBaseE
 
     @catchall
     def text_changed_cb(self, *args):
+        if self.group is None:
+            return
         lwidth = self.label.get_property('width')
         bwidth = self.texture.get_property('width')
 

--- a/mfp/gui/clutter/plot_element.py
+++ b/mfp/gui/clutter/plot_element.py
@@ -119,11 +119,11 @@ class ClutterPlotElementImpl(PlotElement, PlotElementImpl, ClutterBaseElementBac
 
     def select(self):
         super().select()
-        self.rect.set_border_color(self.app_window.color_selected)
+        self.rect.set_border_color(self.app_window.wrapper.color_selected)
 
     def unselect(self):
         super().unselect()
-        self.rect.set_border_color(self.app_window.color_unselected)
+        self.rect.set_border_color(self.app_window.wrapper.color_unselected)
 
     def command(self, action, data):
         if self.xyplot.command(action, data):

--- a/mfp/gui/clutter/processor_element.py
+++ b/mfp/gui/clutter/processor_element.py
@@ -29,11 +29,22 @@ class ClutterProcessorElementImpl(ProcessorElement, ProcessorElementImpl, Clutte
         self.group.set_reactive(True)
 
         # resize widget whne text gets longer
-        self.label.signal_listen('text-changed', self.label_changed_cb)
+        self.handler_id = self.label.signal_listen('text-changed', self.label_changed_cb)
         self.set_size(35, 25)
         self.move(x, y)
 
         self.redraw()
+
+    async def delete(self):
+        if self.texture:
+            self.group.set_content(None)
+            self.texture = None
+        if self.label:
+            self.label.signal_unlisten(self.handler_id)
+            await self.label.delete()
+            self.label = None
+
+        await super().delete()
 
     def redraw(self):
         super().redraw()
@@ -56,8 +67,10 @@ class ClutterProcessorElementImpl(ProcessorElement, ProcessorElementImpl, Clutte
 
     def unselect(self):
         super().unselect()
-        self.label.set_color(self.get_color('text-color'))
-        self.texture.invalidate()
+        if self.label:
+            self.label.set_color(self.get_color('text-color'))
+        if self.texture:
+            self.texture.invalidate()
 
     def draw_cb(self, texture, ct, width, height):
         lw = 2.0

--- a/mfp/gui/clutter/text_widget.py
+++ b/mfp/gui/clutter/text_widget.py
@@ -28,6 +28,9 @@ class ClutterTextWidgetImpl(TextWidget, TextWidgetImpl):
         self.label = Clutter.Text()
         self.parent.add_actor(self.label)
 
+        if hasattr(self.container, 'app_window'):
+            self.container.app_window.event_sources[self.label] = self.container
+
         self.key_press_handler_id = None
         self.edit_mode = None
 
@@ -37,8 +40,15 @@ class ClutterTextWidgetImpl(TextWidget, TextWidgetImpl):
         self.label.connect("key-focus-out", repeat_event(self, "key-focus-out"))
         self.label.connect("key-focus-in", repeat_event(self, "key-focus-in"))
 
+    async def delete(self):
+        if self.label:
+            if hasattr(self.container, 'app_window') and self.label in self.container.app_window.event_sources:
+                del self.container.app_window.event_sources[self.label]
+            self.label.destroy()
+            self.label = None
+
     def grab_focus(self):
-        return self.label.grab_key_focus()
+        return self.label.grab_key_focus() if self.label else None
 
     def show(self):
         return self.parent.add_actor(self.label)
@@ -68,10 +78,10 @@ class ClutterTextWidgetImpl(TextWidget, TextWidgetImpl):
         return self.label.get_cursor_position()
 
     def set_cursor_position(self, pos):
-        return self.label.set_cursor_position(pos)
+        return self.label.set_cursor_position(pos) if self.label else None
 
     def set_cursor_visible(self, visible):
-        return self.label.set_cursor_visible(visible)
+        return self.label.set_cursor_visible(visible) if self.label else None
 
     def set_cursor_color(self, color):
         return self.label.set_cursor_color(color)
@@ -80,7 +90,7 @@ class ClutterTextWidgetImpl(TextWidget, TextWidgetImpl):
         return self.label.get_text()
 
     def set_text(self, text):
-        return self.label.set_text(text)
+        return self.label.set_text(text) if self.label else None
 
     def set_markup(self, text):
         return self.label.set_markup(text)
@@ -98,7 +108,7 @@ class ClutterTextWidgetImpl(TextWidget, TextWidgetImpl):
         return self.label.get_property(propname)
 
     def set_use_markup(self, use_markup):
-        return self.label.set_use_markup(use_markup)
+        return self.label.set_use_markup(use_markup) if self.label else None
 
     def set_selection(self, start, end):
         return self.label.set_selection(start, end)

--- a/mfp/gui/input_manager.py
+++ b/mfp/gui/input_manager.py
@@ -27,7 +27,6 @@ class InputManager (object):
         self.minor_modes = []
         self.minor_seqno = 0
         self.keyseq = KeySequencer()
-        self.event_sources = {}
         self.root_source = None
         self.pointer_x = None
         self.pointer_y = None

--- a/mfp/gui/message_element.py
+++ b/mfp/gui/message_element.py
@@ -111,7 +111,8 @@ class MessageElement (BaseElement):
 
     def unselect(self):
         BaseElement.unselect(self)
-        self.label.set_color(self.get_color('text-color'))
+        if self.label:
+            self.label.set_color(self.get_color('text-color'))
         self.redraw()
 
     async def make_edit_mode(self):

--- a/mfp/gui/modes/global_mode.py
+++ b/mfp/gui/modes/global_mode.py
@@ -7,6 +7,7 @@ Copyright (c) 2012 Bill Gribble <grib@billgribble.com>
 
 from mfp.gui_main import MFPGUI
 from mfp import log
+from mfp.gui.collision import collision_check
 from ..input_mode import InputMode
 from .label_edit import LabelEditMode
 from .transient import TransientMessageEditMode
@@ -225,6 +226,22 @@ class GlobalMode (InputMode):
         return True
 
     async def selbox_start(self, select_mode):
+
+        px = self.manager.pointer_x
+        py = self.manager.pointer_y
+        enclosed = []
+        selection_corners = [(px, py), (px+1, py), (px+1, py+1), (px, py+1)]
+
+        for obj in self.window.selected_layer.objects:
+            if obj.parent_id and MFPGUI().recall(obj.parent_id).parent_id:
+                continue
+            corners = obj.corners()
+
+            if corners and collision_check(selection_corners, corners):
+                enclosed.append(obj)
+        if enclosed:
+            self.manager.pointer_obj = enclosed[0]
+
         if select_mode is None:
             if self.manager.pointer_obj is not None:
                 if self.manager.pointer_obj not in self.window.selected:


### PR DESCRIPTION
Lots of debugging on the select issues points the finger at Clutter bugs and/or resource exhaustion. 

* No problems on small patches
* When patches get big or an MFP session has been going a while, problems start

The actual bad behavior of not being able to select comes up because "in certain circumstances" (i.e. I don't exactly know why or how this starts) the `ClutterEnterEvent` that we use to know which object the pointer is over starts putting a variety of surprising values in the `event.source` (which we expect to be the `Clutter.Group` associated with the element). Sometimes the `event.source` is a related object, such as a `Clutter.Text` label, sometimes it's an invisible object such as the un-shown `Clutter.CairoCanvas` associated with the "badge", sometimes it's an object that's part of an element way way away from the pointer. 

This PR puts a variety of remediations in place that help this behavior A LOT but don't entirely fix it.

* call `.destroy()` on any resources that can be freed when an element is deleted, and try hard to drop any references that could keep references to dead objects
* Register sub-elements (in/out port boxes, drawable surfaces, text labels) as potential event sources 
* Don't trust the `pointer_obj` when we start a selection, compute it via collision with the current pointer (x,y) which seems reliable

Symptoms that persist include that HOVER events are sometimes for the wrong object or no object, so the HUD overlay for tooltips about the hovered element can be wrong. But clicking on the element fixes that, and selection basically always works correctly now.