### PR TITLE
add NSM keys to .desktop file

### DIFF
--- a/mfp.desktop
+++ b/mfp.desktop
@@ -5,4 +5,6 @@ Type=Application
 Terminal=false
 Exec=${PREFIX}/bin/mfp
 Name=mfp
+X-NSM-Capable=true
+X-NSM-Exec=mfp
 Icon=${PREFIX}/share/mfp/icons/hicolor/scalable/actions/mfp.svg


### PR DESCRIPTION
This adds NSM related keys to the desktop file, so NSM related tools can find applications with NSM support.