### PR TITLE
#327: Add image loading to Markdown text

### DIFF
--- a/mfp/gui/image_utils.py
+++ b/mfp/gui/image_utils.py
@@ -1,0 +1,74 @@
+"""
+image_utils.py -- load and convert images
+"""
+
+import os
+import numpy as np
+from mfp.gui_main import MFPGUI
+from mfp.utils import find_file_in_path
+
+image_cache = {}
+texture_cache = {}
+
+
+def image_to_texture(pil_image):
+    from OpenGL import GL
+    np_image = np.array(pil_image)
+    assert np_image.dtype == np.uint8 and np_image.ndim == 3 and np_image.shape[2] == 4
+
+    height, width = np_image.shape[:2]
+
+    # Generate a texture ID
+    texture_id = GL.glGenTextures(1)
+    GL.glBindTexture(GL.GL_TEXTURE_2D, texture_id)
+
+    # Set texture parameters (you may want to adjust this)
+    GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR)
+    GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR)
+    GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_S, GL.GL_CLAMP_TO_EDGE)
+    GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_T, GL.GL_CLAMP_TO_EDGE)
+
+    # Upload the image
+    GL.glTexImage2D(
+        GL.GL_TEXTURE_2D,
+        0,                  # level
+        GL.GL_RGBA,            # internal format
+        width,
+        height,
+        0,                  # border
+        GL.GL_RGBA,            # input format
+        GL.GL_UNSIGNED_BYTE,   # input type
+        np_image
+    )
+
+    GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
+    return texture_id, width, height
+
+
+def load_texture_from_file(filename):
+    if filename in texture_cache:
+        return texture_cache[filename]
+
+    pil_image = load_image_from_file(filename)
+    texture_id, width, height = image_to_texture(pil_image)
+    texture_cache[filename] = (texture_id, width, height)
+    return texture_id, width, height
+
+
+def load_image_from_file(filename):
+    from PIL import Image
+    if filename in image_cache:
+        return image_cache[filename]
+
+    loadpath = os.path.dirname(filename)
+    loadfile = os.path.basename(filename)
+
+    searchpath = MFPGUI().searchpath + ((':' + loadpath) if loadpath else "")
+
+    path = find_file_in_path(loadfile, searchpath)
+    if not path:
+        return None
+
+    pil_image = Image.open(path).convert("RGBA")
+    image_cache[filename] = pil_image
+    return pil_image

--- a/mfp/gui/imgui/app_window/app_window.py
+++ b/mfp/gui/imgui/app_window/app_window.py
@@ -147,6 +147,7 @@ class ImguiAppWindowImpl(AppWindow, AppWindowImpl):
 
         md_options = markdown.MarkdownOptions()
         md_options.callbacks.on_html_div = ImguiTextWidgetImpl.markdown_div_callback
+        md_options.callbacks.on_image = ImguiTextWidgetImpl.image_callback
         md_options.font_options.regular_size = 16
         md_options.font_options.size_diff_between_levels = 4
         md_options.font_options.max_header_level = 5

--- a/mfp/gui/imgui/app_window/app_window.py
+++ b/mfp/gui/imgui/app_window/app_window.py
@@ -148,6 +148,7 @@ class ImguiAppWindowImpl(AppWindow, AppWindowImpl):
         md_options = markdown.MarkdownOptions()
         md_options.callbacks.on_html_div = ImguiTextWidgetImpl.markdown_div_callback
         md_options.callbacks.on_image = ImguiTextWidgetImpl.image_callback
+        md_options.callbacks.on_open_link = ImguiTextWidgetImpl.url_callback
         md_options.font_options.regular_size = 16
         md_options.font_options.size_diff_between_levels = 4
         md_options.font_options.max_header_level = 5

--- a/mfp/gui/imgui/app_window/info_panel.py
+++ b/mfp/gui/imgui/app_window/info_panel.py
@@ -257,7 +257,11 @@ def render_param(
                     step=1,
                     step_fast=10,
                 )
-                changed = changed and imgui.is_item_deactivated_after_edit()
+                if changed:
+                    delta = abs(newval - param_value)
+                    if delta > 10:
+                        changed = changed and imgui.is_item_deactivated_after_edit()
+
                 changed = changed or show_input_changed
             else:
                 changed = show_input_changed
@@ -291,9 +295,13 @@ def render_param(
                     step_fast=10,
                     format="%.2f",
                 )
-                changed = changed and imgui.is_item_deactivated_after_edit()
-                imgui.pop_style_var()
+                if changed:
+                    delta = abs(newval - param_value)
+                    if delta > 10:
+                        changed = changed and imgui.is_item_deactivated_after_edit()
+
                 changed = changed or show_input_changed
+                imgui.pop_style_var()
             else:
                 changed = show_input_changed
                 newval = None

--- a/mfp/gui/imgui/text_widget.py
+++ b/mfp/gui/imgui/text_widget.py
@@ -3,6 +3,7 @@ imgui/text_widget.py -- backend implementation of TextWidget for Imgui
 """
 
 import re
+import numpy as np
 from imgui_bundle import imgui, ImVec4
 from imgui_bundle import imgui_node_editor as nedit
 from imgui_bundle import imgui_md as markdown
@@ -11,6 +12,64 @@ from mfp import log
 from mfp.gui_main import MFPGUI
 from mfp.gui.colordb import ColorDB
 from ..text_widget import TextWidget, TextWidgetImpl
+
+
+image_cache = {}
+
+
+def rgba_image_to_texture(image: np.ndarray) -> int:
+    """Upload an RGBA image to the GPU as a texture, returns the OpenGL texture ID."""
+    from OpenGL import GL
+    assert image.dtype == np.uint8 and image.ndim == 3 and image.shape[2] == 4
+
+    height, width = image.shape[:2]
+
+    # Generate a texture ID
+    texture_id = GL.glGenTextures(1)
+    GL.glBindTexture(GL.GL_TEXTURE_2D, texture_id)
+
+    # Set texture parameters (you may want to adjust this)
+    GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR)
+    GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR)
+    GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_S, GL.GL_CLAMP_TO_EDGE)
+    GL.glTexParameteri(GL.GL_TEXTURE_2D, GL.GL_TEXTURE_WRAP_T, GL.GL_CLAMP_TO_EDGE)
+
+    # Upload the image
+    GL.glTexImage2D(
+        GL.GL_TEXTURE_2D,
+        0,                  # level
+        GL.GL_RGBA,            # internal format
+        width,
+        height,
+        0,                  # border
+        GL.GL_RGBA,            # input format
+        GL.GL_UNSIGNED_BYTE,   # input type
+        image
+    )
+
+    GL.glBindTexture(GL.GL_TEXTURE_2D, 0)
+    return texture_id
+
+
+def img_from_file(filename):
+    from PIL import Image
+    if filename in image_cache:
+        return image_cache[filename]
+
+    image = Image.open(filename).convert("RGBA")
+    np_image = np.array(image)
+
+    img = markdown.MarkdownImage()
+    img.texture_id = rgba_image_to_texture(np_image)
+    img.col_border = (0, 0, 0, 0)
+    img.col_tint = (1, 1, 1, 1)
+    img.uv0 = (0, 0)
+    img.uv1 = (1, 1)
+    img.size = np_image.shape[:2]
+    image_cache[filename] = img
+
+    return img
+
 
 # parse the get_debug_name() output to get shape and size info
 def _fontinfo(info):
@@ -100,6 +159,10 @@ class ImguiTextWidgetImpl(TextWidget, TextWidgetImpl):
             nedit.enable_shortcuts(False)
         else:
             nedit.enable_shortcuts(True)
+
+    @classmethod
+    def image_callback(cls, filepath):
+        return img_from_file(filepath)
 
     @classmethod
     def markdown_div_callback(cls, div_class, is_opening_div):

--- a/mfp/gui_main.py
+++ b/mfp/gui_main.py
@@ -271,6 +271,7 @@ async def main(cmdline):
     socketpath = cmdline.get("socketpath")
     debug = cmdline.get('debug')
     backend = cmdline.get('backend')
+    searchpath = cmdline.get('searchpath')
 
     log.log_module = "gui"
     log.log_func = log.rpclog
@@ -321,6 +322,7 @@ async def main(cmdline):
     gui.mfp = mfp_connection
     gui.debug = debug
     gui.backend_name = backend
+    gui.searchpath = searchpath
 
     gui.appwin = AppWindow.build()
 
@@ -371,6 +373,8 @@ def main_sync_wrapper():
                         help="Enable debugging behaviors")
     parser.add_argument("-b", "--backend", default="clutter",
                         help="UI framework to use")
+    parser.add_argument("-p", "--searchpath", default="",
+                        help="Paths to search for assets (colon-separated string)")
     cmdline = vars(parser.parse_args())
 
     backend_name = cmdline.get("backend")

--- a/mfp/mfp_app.py
+++ b/mfp/mfp_app.py
@@ -135,7 +135,13 @@ class MFPApp (Singleton, SignalMixin):
 
         if not self.no_gui:
             logstart = log.log_time_base.strftime("%Y-%m-%dT%H:%M:%S.%f")
-            guicmd = ["mfpgui", "-s", self.socket_path, "-l", logstart, '--backend', self.gui_backend]
+            guicmd = [
+                "mfpgui",
+                "-s", self.socket_path,
+                "-l", logstart,
+                '--backend', self.gui_backend,
+                "--searchpath", self.searchpath
+            ]
             if self.debug:
                 guicmd.append('--debug')
 
@@ -350,17 +356,16 @@ class MFPApp (Singleton, SignalMixin):
             loadpath = os.path.dirname(file_name)
             loadfile = os.path.basename(file_name)
 
-            # FIXME: should not modify app search path, it should be just for this load
-            self.searchpath += ':' + loadpath
+            searchpath = self.searchpath + ((':' + loadpath) if loadpath else "")
 
             log.debug("Opening patch", loadfile)
-            filepath = utils.find_file_in_path(loadfile, self.searchpath)
+            filepath = utils.find_file_in_path(loadfile, searchpath)
 
             if filepath:
                 log.debug("Found file", filepath)
                 (name, factory) = Patch.register_file(filepath)
             else:
-                log.error("No file '%s' in search path %s" % (loadfile, MFPApp().searchpath))
+                log.error("No file '%s' in search path %s" % (loadfile, searchpath))
                 if "." in loadfile:
                     name = '.'.join(loadfile.split('.')[:-1])
                 else:


### PR DESCRIPTION
Markdown images are loaded with this syntax:

```
![image text](image_filename.png)
```

The filename is searched for in the MFP search path (add directories with the `-p` command line option)

There are limits:

* The image needs to be a format that is understood by [PIL](https://pypi.org/project/pillow/)
* The display size can't be changed (limitation of Markdown image syntax) 
* The filename can have no spaces in it (limitation of `imgui_md`


