### PR TITLE
#326: Add "panel mode" 

### DIFF
--- a/mfp/gui/app_window.py
+++ b/mfp/gui/app_window.py
@@ -239,6 +239,7 @@ class AppWindow (SignalMixin):
         return cls.get_backend(MFPGUI().backend_name)(*args, **kwargs)
 
     def input_handler(self, target, signal, event, *rest):
+        from mfp.gui.event import EnterEvent
         try:
             rv = self.input_mgr.handle_event(target, event)
             self.grab_focus()
@@ -301,8 +302,15 @@ class AppWindow (SignalMixin):
             )
 
     def object_visible(self, obj):
+        patch = None
+        if self.selected_layer:
+            patch = self.selected_layer.patch
+        if patch and patch.panel_mode:
+            return obj.panel_enable
         if obj and hasattr(obj, 'layer'):
             return obj.layer == self.selected_layer
+        if obj == self.console_manager:
+            return True
         return True
 
     def active_layer(self):

--- a/mfp/gui/base_element.py
+++ b/mfp/gui/base_element.py
@@ -475,8 +475,11 @@ class BaseElement (Store):
 
         self.tags = {}
         self.update_badge()
-        objinfo = await MFPGUI().mfp.create(obj_type, init_args, patchname, scopename, name, self.synced_params())
+        params = self.synced_params()
+        objinfo = await MFPGUI().mfp.create(obj_type, init_args, patchname, scopename, name, params)
+
         if not objinfo or "obj_id" not in objinfo:
+            log.debug(f"[base_element] error: {objinfo}")
             self.app_window.hud_write("ERROR: Could not create, see log for details")
 
             if objinfo and "code" in objinfo:
@@ -490,6 +493,7 @@ class BaseElement (Store):
 
         if self.layer is not None and objinfo and isinstance(objinfo, dict):
             objinfo["layername"] = self.layer.name
+
         objinfo['obj_type'] = obj_type
         objinfo['obj_state'] = self.obj_state
 
@@ -547,7 +551,6 @@ class BaseElement (Store):
         Initialize store from creation payload
         """
         objinfo = action.payload
-        log.debug(f"[CREATE_OBJECT] state={state} previous_value={previous_value} new={objinfo.get(state)}")
         if state in (
             'obj_id', 'obj_type', 'obj_state',
             'scope', 'num_inlets', 'num_outlets', 'dsp_inlets', 'dsp_outlets',
@@ -566,7 +569,7 @@ class BaseElement (Store):
         prms = {}
         for k in self.param_list:
             val = getattr(self, k)
-            if k == "layer":
+            if k == "layer" and val:
                 prms["layername"] = val.name
                 continue
             if isinstance(val, BaseElement):

--- a/mfp/gui/base_element.py
+++ b/mfp/gui/base_element.py
@@ -66,6 +66,13 @@ BASE_STORE_ATTRS = {
     'position_x': ParamInfo(label="X position", param_type=float),
     'position_y': ParamInfo(label="Y position", param_type=float),
     'position_z': ParamInfo(label="Z position", param_type=float),
+    'patch_x': ParamInfo(label="X position (patch mode)", param_type=float),
+    'patch_y': ParamInfo(label="Y position (patch mode)", param_type=float),
+    'patch_z': ParamInfo(label="Z position (patch mode)", param_type=float),
+    'panel_x': ParamInfo(label="X position (panel mode)", param_type=float),
+    'panel_y': ParamInfo(label="Y position (panel mode)", param_type=float),
+    'panel_z': ParamInfo(label="Z position (panel mode)", param_type=float),
+    'panel_enable': ParamInfo(label="Enable panel display", param_type=bool, show=True),
     'width': ParamInfo(label="Width", param_type=float, editable=False),
     'height': ParamInfo(label="Height", param_type=float, editable=False),
     'min_width': ParamInfo(label="Min width", param_type=float),
@@ -86,7 +93,7 @@ BASE_STORE_ATTRS = {
 }
 
 # these are params that may appear within 'properties' and get
-# their own editors. It's awkward to have type-specific info here 
+# their own editors. It's awkward to have type-specific info here
 # and in the Processor definition but I can't see a way around it
 PROPERTY_ATTRS = {
     'lv2_type': ParamInfo(
@@ -196,6 +203,14 @@ class BaseElement (Store):
         self.properties = {}
         self.style = {}
         self._all_styles = self.combine_styles()
+
+        self.patch_x = x
+        self.patch_y = y
+        self.patch_z = 0
+        self.panel_x = x
+        self.panel_y = y
+        self.panel_z = 0
+        self.panel_enable = False
 
         # for interactive search
         self.highlight_text = None
@@ -361,12 +376,46 @@ class BaseElement (Store):
                     previous=dict(position_y=previous_y)
                 )
         else:
+            log.debug(f"[move] not updating state from {(previous_x, previous_y)} to {(x, y)}")
             self.position_x = x
             self.position_y = y
 
     @saga('code', 'properties')
     async def params_changed(self, action, state_diff, previous):
         yield self.send_params()
+
+    @saga('position_x', 'position_y', 'position_z')
+    async def position_changed(self, action, state_diff, previous):
+        if not (self.layer and self.layer.patch):
+            return
+
+        if self.layer.patch.panel_mode or not self.panel_enable:
+            if 'position_x' in state_diff:
+                yield self.action(
+                    self.SET_PANEL_X, value=self.position_x
+                )
+            if 'position_y' in state_diff:
+                yield self.action(
+                    self.SET_PANEL_Y, value=self.position_y
+                )
+            if 'position_z' in state_diff:
+                yield self.action(
+                    self.SET_PANEL_Z, value=self.position_z
+                )
+
+        if not self.layer.patch.panel_mode:
+            if 'position_x' in state_diff:
+                yield self.action(
+                    self.SET_PATCH_X, value=self.position_x
+                )
+            if 'position_y' in state_diff:
+                yield self.action(
+                    self.SET_PATCH_Y, value=self.position_y
+                )
+            if 'position_z' in state_diff:
+                yield self.action(
+                    self.SET_PATCH_Z, value=self.position_z
+                )
 
     @mutates('obj_state')
     async def delete(self, delete_obj=True):
@@ -388,6 +437,7 @@ class BaseElement (Store):
         new_layer = action.payload['value']
         self.move_to_layer(new_layer)
         return new_layer
+
 
     @saga('style')
     async def update_all_styles(self, action, state_diff, previous):
@@ -420,8 +470,8 @@ class BaseElement (Store):
         # get put in the correct place in the object tree
         await MFPGUI().appwin.signal_emit("created", self)
 
-        self.obj_type = obj_type
-        self.obj_args = init_args
+        #self.obj_type = obj_type
+        #self.obj_args = init_args
 
         self.tags = {}
         self.update_badge()
@@ -441,10 +491,12 @@ class BaseElement (Store):
         if self.layer is not None and objinfo and isinstance(objinfo, dict):
             objinfo["layername"] = self.layer.name
         objinfo['obj_type'] = obj_type
+        objinfo['obj_state'] = self.obj_state
 
         # init state from objinfo
         await self.dispatch(
-            Action(self, self.CREATE_OBJECT, objinfo)
+            Action(self, self.CREATE_OBJECT, objinfo),
+            previous=dict(obj_state=None)
         )
 
         if self.obj_id is not None:
@@ -488,15 +540,17 @@ class BaseElement (Store):
 
     @reducer(
         'obj_id', 'scope', 'num_inlets', 'num_outlets', 'dsp_inlets', 'dsp_outlets',
-        'obj_type', 'obj_name', 'obj_args', 'properties'
+        'obj_type', 'obj_name', 'obj_args', 'obj_state', 'properties'
     )
     def CREATE_OBJECT(self, action, state, previous_value):
         """
         Initialize store from creation payload
         """
         objinfo = action.payload
+        log.debug(f"[CREATE_OBJECT] state={state} previous_value={previous_value} new={objinfo.get(state)}")
         if state in (
-            'obj_id', 'obj_type', 'scope', 'num_inlets', 'num_outlets', 'dsp_inlets', 'dsp_outlets',
+            'obj_id', 'obj_type', 'obj_state',
+            'scope', 'num_inlets', 'num_outlets', 'dsp_inlets', 'dsp_outlets',
             'properties'
         ):
             return objinfo.get(state, previous_value)
@@ -505,6 +559,7 @@ class BaseElement (Store):
             return objinfo.get('name', previous_value)
         if state == 'obj_args':
             return objinfo.get('initargs', previous_value)
+
         return previous_value
 
     def synced_params(self):
@@ -600,7 +655,9 @@ class BaseElement (Store):
     @mutates(
         'num_inlets', 'num_outlets', 'dsp_inlets', 'dsp_outlets',
         'obj_name', 'no_export', 'is_export', 'export_offset_x',
-        'export_offset_y', 'debug', 'layer', 'code', 'properties'
+        'export_offset_y', 'debug', 'layer', 'code', 'properties',
+        'panel_x', 'panel_y', 'panel_z', 'panel_enable',
+        'patch_x', 'patch_y', 'patch_z'
     )
     async def configure(self, params):
         self.num_inlets = params.get("num_inlets", 0)
@@ -612,6 +669,13 @@ class BaseElement (Store):
         self.is_export = params.get("is_export", False)
         self.export_offset_x = params.get("export_offset_x", 0)
         self.export_offset_y = params.get("export_offset_y", 0)
+        self.patch_x = params.get("patch_x", self.patch_x)
+        self.patch_y = params.get("patch_y", self.patch_y)
+        self.patch_z = params.get("patch_z", self.patch_z)
+        self.panel_x = params.get("panel_x", self.panel_x)
+        self.panel_y = params.get("panel_y", self.panel_y)
+        self.panel_z = params.get("panel_z", self.panel_z)
+        self.panel_enable = params.get("panel_enable", self.panel_enable)
         self.debug = params.get("debug", False)
         self.code = params.get("code", None)
         self.properties = params.get("properties", {})

--- a/mfp/gui/imgui/app_window/app_window.py
+++ b/mfp/gui/imgui/app_window/app_window.py
@@ -487,13 +487,6 @@ class ImguiAppWindowImpl(AppWindow, AppWindowImpl):
     def ready(self):
         pass
 
-    def object_visible(self, obj):
-        if obj and hasattr(obj, 'layer'):
-            return obj.layer == self.selected_layer
-        if obj == self.console_manager:
-            return True
-        return True
-
     #####################
     # coordinate transforms and zoom
     def screen_to_canvas(self, x, y):

--- a/mfp/gui/imgui/app_window/canvas_panel.py
+++ b/mfp/gui/imgui/app_window/canvas_panel.py
@@ -1,5 +1,5 @@
 """
-canvas_pane -- render the 'imgui node editor' canvas pane
+canvas_panel -- render the 'imgui node editor' canvas pane
 
 Copyright (c) Bill Gribble <grib@billgribble.com>
 """

--- a/mfp/gui/imgui/app_window/canvas_panel.py
+++ b/mfp/gui/imgui/app_window/canvas_panel.py
@@ -213,7 +213,18 @@ def render_tile(app_window, patch):
                 nedit.select_node(obj.node_id, True)
         app_window.imgui_needs_reselect = []
 
-    if patch.selected_layer:
+    if patch.panel_mode:
+        panel_objects = []
+        for layer in patch.layers:
+            for obj in layer.objects:
+                if obj.panel_enable:
+                    panel_objects.append(obj)
+
+        for obj in sorted(panel_objects, key=lambda o: o.panel_z):
+            if not isinstance(obj, ConnectionElement):
+                obj.render()
+
+    elif patch.selected_layer:
         # first pass: non-links
         all_pins = {}
         for obj in sorted(patch.selected_layer.objects, key=lambda o: o.position_z):

--- a/mfp/gui/imgui/app_window/canvas_panel.py
+++ b/mfp/gui/imgui/app_window/canvas_panel.py
@@ -90,7 +90,9 @@ def render_tile(app_window, patch):
         patch.nedit_editor = nedit.create_editor(app_window.nedit_config)
     nedit.set_current_editor(patch.nedit_editor)
     layer_name = ''
-    if patch.selected_layer:
+    if patch.panel_mode:
+        layer_name = ' (panel)'
+    elif patch.selected_layer:
         layer_name = ' - ' + patch.selected_layer.name
 
     if app_window.viewport_selection_set:

--- a/mfp/gui/imgui/app_window/info_panel.py
+++ b/mfp/gui/imgui/app_window/info_panel.py
@@ -29,6 +29,7 @@ single_params = [
     'layer',
     'min_width',
     'min_height',
+    'panel_enable',
 ]
 
 

--- a/mfp/gui/imgui/base_element.py
+++ b/mfp/gui/imgui/base_element.py
@@ -129,20 +129,22 @@ class ImguiBaseElementImpl(BaseElementImpl):
     # every subclass should call this somewhere in the render method
     def render_sync_with_imgui(self):
         if isinstance(self.container, BaseElement):
+            # we are creating a subobject within a processor_element
             if self.export_position_init:
                 self.export_position_init = False
-                self.position_x = self.container.position_x + self.position_x
-                self.position_y = self.container.position_y + self.position_y
+                self.position_x = self.container.position_x + self.panel_x + self.export_offset_x
+                self.position_y = self.container.position_y + self.panel_y + self.export_offset_y
                 self.position_z = self.container.position_z + 0.1
                 self.position_set = True
                 self.export_container_x = self.container.position_x
                 self.export_container_y = self.container.position_y
+            # the containing processor_element has moved
             elif (
                 self.container.position_x != self.export_container_x
                 or self.container.position_y != self.export_container_y
             ):
-                self.position_x = (self.container.position_x - self.export_container_x) + self.position_x
-                self.position_y = (self.container.position_y - self.export_container_y) + self.position_y
+                self.position_x = self.container.position_x + self.panel_x + self.export_offset_x
+                self.position_y = self.container.position_y + self.panel_y + self.export_offset_y
                 self.position_z = self.container.position_z + 0.1
                 self.position_set = True
                 self.export_container_x = self.container.position_x

--- a/mfp/gui/imgui/base_element.py
+++ b/mfp/gui/imgui/base_element.py
@@ -286,6 +286,8 @@ class ImguiBaseElementImpl(BaseElementImpl):
             return
         if not self.selected and not self.editable:
             return
+        if self.container and self.container.panel_mode and self.panel_enable:
+            return
 
         padding = self.get_style('padding')
         p_tl = imgui.get_item_rect_min()

--- a/mfp/gui/layer.py
+++ b/mfp/gui/layer.py
@@ -30,6 +30,10 @@ class Layer(BackendInterface):
     def build(cls, *args, **kwargs):
         return cls.get_backend(MFPGUI().backend_name)(*args, **kwargs)
 
+    @property
+    def panel_mode(self):
+        return self.patch.panel_mode if self.patch else False
+
     def resort(self, obj):
         if obj in self.objects:
             self.objects.remove(obj)

--- a/mfp/gui/modes/global_mode.py
+++ b/mfp/gui/modes/global_mode.py
@@ -8,6 +8,7 @@ Copyright (c) 2012 Bill Gribble <grib@billgribble.com>
 import inspect
 from mfp.gui_main import MFPGUI, backend_name
 from mfp import log
+from flopsy import Action
 from ..input_mode import InputMode
 from .label_edit import LabelEditMode
 from .transient import TransientMessageEditMode
@@ -283,12 +284,29 @@ class GlobalMode (InputMode):
             keysym="$"
         )
 
+        cls.bind(
+            "toggle-panel-mode", cls.toggle_panel_mode,
+            helptext="Toggle panel mode",
+            keysym="C-ESC"
+        )
+
         # imgui only
         if backend_name == "imgui":
             cls.bind(
                 "tile-control", cls.tile_manager_prefix,
                 keysym="C-a"
             )
+
+    async def toggle_panel_mode(self):
+        patch = self.window.selected_patch
+        log.debug(f"[panel] setting panel mode for {patch} to {not patch.panel_mode}")
+        await patch.dispatch(
+            Action(patch, patch.SET_PANEL_MODE, dict(value=(not patch.panel_mode))),
+            previous=dict(panel_mode=patch.panel_mode)
+        )
+        log.debug(f"[panel] panel mode is now {patch.panel_mode}")
+
+        return True
 
     def tile_manager_prefix(self):
         if not self.tile_manager_mode:

--- a/mfp/gui/modes/global_mode.py
+++ b/mfp/gui/modes/global_mode.py
@@ -528,6 +528,7 @@ class GlobalMode (InputMode):
                 self.window.selected_window != "canvas"
                 or self.window.main_menu_open
                 or self.window.context_menu_open
+                or self.window.inspector
                 or nedit.get_hovered_pin().id()
             ):
                 return False

--- a/mfp/gui/modes/global_mode.py
+++ b/mfp/gui/modes/global_mode.py
@@ -299,12 +299,10 @@ class GlobalMode (InputMode):
 
     async def toggle_panel_mode(self):
         patch = self.window.selected_patch
-        log.debug(f"[panel] setting panel mode for {patch} to {not patch.panel_mode}")
         await patch.dispatch(
             Action(patch, patch.SET_PANEL_MODE, dict(value=(not patch.panel_mode))),
             previous=dict(panel_mode=patch.panel_mode)
         )
-        log.debug(f"[panel] panel mode is now {patch.panel_mode}")
 
         return True
 

--- a/mfp/gui/slidemeter_element.py
+++ b/mfp/gui/slidemeter_element.py
@@ -285,7 +285,7 @@ class SlideMeterElement (BaseElement):
             self.scale_position = self.LEFT
             changes = True
 
-        for p in ("show_scale", "slider_enable", "scale_ticks"):
+        for p in ("show_scale", "slider_enable", "scale_ticks", "bar_width", "bar_height"):
             v = params.get(p)
             if v is not None and hasattr(self, p):
                 changes = True

--- a/mfp/gui_command.py
+++ b/mfp/gui_command.py
@@ -153,6 +153,8 @@ class GUICommand:
                         layer = parent.find_layer(params["layername"])
                     if not layer:
                         layer = parent.selected_layer or parent.layers[0]
+                    if not layer:
+                        log.debug(f"[create] NO LAYER! {params} {parent}")
                     o.container = layer
                     layer.add(o)
                 elif isinstance(parent, BaseElement):
@@ -163,6 +165,8 @@ class GUICommand:
                         )
                     o.editable = False
                     o.container = parent
+                    if not parent.layer:
+                        log.debug(f"[create] NO PARENT LAYER! {params} {parent}")
                     parent.layer.add(o, container=parent)
                 await o.configure(params)
                 MFPGUI().appwin.register(o)

--- a/mfp/mfp_app.py
+++ b/mfp/mfp_app.py
@@ -404,9 +404,6 @@ class MFPApp (Singleton, SignalMixin):
         create_params = {}
         rval = None
 
-        # first try: is a factory registered?
-        ctor = self.registry.get(init_type)
-
         # try to compile code to get extra defs
         defs = {}
         if params and "code" in params:
@@ -419,6 +416,9 @@ class MFPApp (Singleton, SignalMixin):
                     rval = create_params
                 else:
                     create_params["code"] = dict(body=codestr, lang="python")
+
+        # first try: is a factory registered?
+        ctor = self.registry.get(init_type)
 
         # second try: is there a .mfp patch file in the search path?
         if ctor is None:

--- a/mfp/patch.py
+++ b/mfp/patch.py
@@ -546,12 +546,7 @@ class Patch(Processor):
         return True
 
     def obj_is_exportable(self, obj):
-        if (obj.gui_params.get('is_export')
-            or (obj.gui_params.get("layername") == Patch.EXPORT_LAYER
-                and obj.gui_params.get("no_export", False) is not True
-                and "display_type" in obj.gui_params
-                and (obj.gui_params.get("display_type") not in
-                     ("sendvia", "recvvia", "sendsignalvia", "recvsignalvia")))):
+        if obj.gui_params.get('is_export') or obj.gui_params.get("panel_enable"):
             return True
         else:
             return False
@@ -561,10 +556,16 @@ class Patch(Processor):
 
         for obj_id, obj in self.objects.items():
             if self.obj_is_exportable(obj):
-                x = (obj.gui_params.get("position_x")
-                     - obj.gui_params.get('export_offset_x', 0))
-                y = (obj.gui_params.get("position_y")
-                     - obj.gui_params.get('export_offset_y', 0))
+                obj_x = obj.gui_params.get(
+                    "panel_x",
+                    obj.gui_params.get("position_x", 0)
+                )
+                obj_y = obj.gui_params.get(
+                    "panel_y",
+                    obj.gui_params.get("position_y", 0)
+                )
+                x = obj_x - obj.gui_params.get('export_offset_x', 0)
+                y = obj_y - obj.gui_params.get('export_offset_y', 0)
                 w = obj.gui_params.get("width")
                 h = obj.gui_params.get("height")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ annotated-types==0.7.0
 carp-rpc==0.0.8
 cffi==1.17.1
 Cython==3.0.12
-flopsy==0.0.5
+flopsy==0.0.6
 glfw==2.8.0
 imgui-bundle==1.6.2
 munch==4.0.0


### PR DESCRIPTION
This is for #326. Panel mode is similar to Max's "presentation mode". It allows a patch to define a curated visual format that is more suitable for interaction and performance. 

* Patch elements have a new checkbox in the "Object" tab of the right-side info pane. Selecting it adds the element to the panel.
* Once an element is added to the panel, it will show on the panel regardless of what layer the element is in
* C-ESC (control + escape) toggles panel mode on and off for a patch
* When in panel mode, elements have a separate X, Y, and Z position from the normal position in "patching mode". To edit, enable patching mode and move the patch elements where you want them; when you change back to patching mode they will return to their previous positions

Panel mode also replaces the "Interface" layer as the source of a layout for when a patch is opened inside a Processor element. For compatibility, older patches that define an Interface layer will still function as expected. 