### PR TITLE
Implement scalable UI and port to imgui 1.92.x

### DIFF
--- a/mfp/gui/imgui/app_window/canvas_panel.py
+++ b/mfp/gui/imgui/app_window/canvas_panel.py
@@ -191,8 +191,8 @@ def render_tile(app_window, patch):
             app_window.get_color('grid-color:operate').to_rgbaf()
         )
 
+    imgui.get_style().font_scale_main = 1.0
     nedit.begin("canvas_editor", (0.0, 0.0))
-
     conf = nedit.get_config()
 
     # disable NodeEditor dragging and selecting unless we are hovering on
@@ -410,6 +410,7 @@ def render_tile(app_window, patch):
 
     nedit.end()  # node_editor
     nedit.pop_style_color(5)
+    imgui.get_style().font_scale_main = app_window.imgui_global_scale
 
     imgui.end()
 

--- a/mfp/gui/imgui/app_window/info_panel.py
+++ b/mfp/gui/imgui/app_window/info_panel.py
@@ -195,7 +195,7 @@ def render_param(
                     if item_selected and choice_label != current_choice[0]:
                         changed = True
                         newval = choice_value
-                imgui.dummy([1, 4])
+                imgui.dummy(app_window.scaled(1, 4))
                 imgui.end_popup()
             imgui.pop_style_var(2)
 
@@ -590,8 +590,8 @@ def render_patch_tab(app_window):
 
     ######################
     # a little padding
-    imgui.dummy([1, TAB_PADDING_Y])
-    imgui.dummy([TAB_PADDING_X, 1])
+    imgui.dummy(app_window.scaled(1, TAB_PADDING_Y))
+    imgui.dummy(app_window.scaled(TAB_PADDING_X, 1))
     imgui.same_line()
 
     imgui.begin_group()
@@ -678,8 +678,8 @@ def render_patch_tab(app_window):
 def render_object_tab(app_window):
     ######################
     # a little padding
-    imgui.dummy([1, TAB_PADDING_Y])
-    imgui.dummy([TAB_PADDING_X, 1])
+    imgui.dummy(app_window.scaled(1, TAB_PADDING_Y))
+    imgui.dummy(app_window.scaled(TAB_PADDING_X, 1))
     imgui.same_line()
 
     imgui.begin_group()
@@ -721,8 +721,8 @@ def render_params_tab(app_window, param_list):
 
     ######################
     # a little padding
-    imgui.dummy([1, TAB_PADDING_Y])
-    imgui.dummy([TAB_PADDING_X, 1])
+    imgui.dummy(app_window.scaled(1, TAB_PADDING_Y))
+    imgui.dummy(app_window.scaled(TAB_PADDING_X, 1))
     imgui.same_line()
 
     imgui.begin_group()
@@ -755,8 +755,8 @@ def render_style_tab(app_window):
 
             # the Element tab is the only on where params can be edited
             if imgui.begin_tab_item("Element")[0]:
-                imgui.dummy([1, TAB_PADDING_Y])
-                imgui.dummy([TAB_PADDING_X, 1])
+                imgui.dummy(app_window.scaled(1, TAB_PADDING_Y))
+                imgui.dummy(app_window.scaled(TAB_PADDING_X, 1))
                 imgui.same_line()
 
                 imgui.begin_group()
@@ -771,8 +771,8 @@ def render_style_tab(app_window):
 
             # defaults for this type of element
             if imgui.begin_tab_item("Type")[0]:
-                imgui.dummy([1, TAB_PADDING_Y])
-                imgui.dummy([TAB_PADDING_X, 1])
+                imgui.dummy(app_window.scaled(1, TAB_PADDING_Y))
+                imgui.dummy(app_window.scaled(TAB_PADDING_X, 1))
                 imgui.same_line()
 
                 imgui.begin_group()
@@ -794,8 +794,8 @@ def render_style_tab(app_window):
 
             # style shared by all element types
             if imgui.begin_tab_item("Base")[0]:
-                imgui.dummy([1, TAB_PADDING_Y])
-                imgui.dummy([TAB_PADDING_X, 1])
+                imgui.dummy(app_window.scaled(1, TAB_PADDING_Y))
+                imgui.dummy(app_window.scaled(TAB_PADDING_X, 1))
                 imgui.same_line()
 
                 imgui.begin_group()
@@ -817,8 +817,8 @@ def render_style_tab(app_window):
                 imgui.end_tab_item()
 
         if imgui.begin_tab_item("Global")[0]:
-            imgui.dummy([1, TAB_PADDING_Y])
-            imgui.dummy([TAB_PADDING_X, 1])
+            imgui.dummy(app_window.scaled(1, TAB_PADDING_Y))
+            imgui.dummy(app_window.scaled(TAB_PADDING_X, 1))
             imgui.same_line()
 
             imgui.begin_group()
@@ -840,8 +840,8 @@ def render_style_tab(app_window):
 
         if len(app_window.selected) == 1:
             if imgui.begin_tab_item("Computed")[0]:
-                imgui.dummy([1, TAB_PADDING_Y])
-                imgui.dummy([TAB_PADDING_X, 1])
+                imgui.dummy(app_window.scaled(1, TAB_PADDING_Y))
+                imgui.dummy(app_window.scaled(TAB_PADDING_X, 1))
                 imgui.same_line()
 
                 imgui.begin_group()
@@ -866,12 +866,12 @@ def render_bindings_tab(app_window):
 
     ######################
     # a little padding
-    imgui.dummy([1, TAB_PADDING_Y])
-    imgui.dummy([TAB_PADDING_X, 1])
+    imgui.dummy(app_window.scaled(1, TAB_PADDING_Y))
+    imgui.dummy(app_window.scaled(TAB_PADDING_X, 1))
     imgui.same_line()
 
     imgui.begin_group()
-    imgui.push_style_var(imgui.StyleVar_.item_spacing, (4.0, 8.0))
+    imgui.push_style_var(imgui.StyleVar_.item_spacing, app_window.scaled(4.0, 8.0))
 
     imgui.text("OSC bindings")
     if imgui.begin_table(
@@ -938,8 +938,8 @@ def render_activity_tab(app_window):
 
     ######################
     # a little padding
-    imgui.dummy([1, TAB_PADDING_Y])
-    imgui.dummy([TAB_PADDING_X, 1])
+    imgui.dummy(app_window.scaled(1, TAB_PADDING_Y))
+    imgui.dummy(app_window.scaled(TAB_PADDING_X, 1))
     imgui.same_line()
 
     imgui.begin_group()

--- a/mfp/gui/imgui/app_window/menu_bar.py
+++ b/mfp/gui/imgui/app_window/menu_bar.py
@@ -47,11 +47,19 @@ def add_menu_items(app_window, itemdict):
                     itemname = itemname[3:]
                 else:
                     itemname = itemname[2:]
-                toggle_state = toggle_items_state.setdefault(menu_path, default_toggle)
+
+                if value.selected and callable(value.selected):
+                    toggle_state = value.selected()
+                elif value.selected is not None:
+                    toggle_state = value.selected
+                else:
+                    toggle_state = toggle_items_state.setdefault(menu_path, default_toggle)
 
             # make the actual menu item
             item_selected, item_toggled = imgui.menu_item(
-                itemname, keysym, toggle_state, value.enabled
+                itemname,
+                '' if keysym.startswith('__') else keysym,
+                toggle_state, value.enabled
             )
 
             # send synthesized keypress(es) if selected
@@ -69,9 +77,9 @@ def add_menu_items(app_window, itemdict):
         sep_items = itemdict.get(separators * '|')
         if not sep_items:
             continue
-        imgui.dummy([1, 2])
+        imgui.dummy(app_window.scaled(1, 2))
         imgui.separator()
-        imgui.dummy([1, 2])
+        imgui.dummy(app_window.scaled(1, 2))
         add_menu_items(app_window, sep_items)
 
 def prune_paths(pathdict):
@@ -185,9 +193,9 @@ def render(app_window):
         menu_open = True
         add_menu_items(app_window, by_menu.get("Layer", {}))
         if app_window.selected_patch and len(app_window.selected_patch.layers) > 0:
-            imgui.dummy([1, 2])
+            imgui.dummy(app_window.scaled(1, 2))
             imgui.separator()
-            imgui.dummy([1, 2])
+            imgui.dummy(app_window.scaled(1, 2))
             for layer_num, layer in enumerate(app_window.selected_patch.layers):
                 imgui.push_id(layer_num)
                 layer_selected, _ = imgui.menu_item(
@@ -205,9 +213,9 @@ def render(app_window):
         add_menu_items(app_window, by_menu.get("Window", {}))
 
         if len(app_window.patches) > 0:
-            imgui.dummy([1, 2])
+            imgui.dummy(app_window.scaled(1, 2))
             imgui.separator()
-            imgui.dummy([1, 2])
+            imgui.dummy(app_window.scaled(1, 2))
             for patch in app_window.patches:
                 if not patch.display_info:
                     continue

--- a/mfp/gui/input_mode.py
+++ b/mfp/gui/input_mode.py
@@ -18,6 +18,7 @@ class Binding:
     keysym: str
     menupath: str = ''
     mode: any = None
+    selected: any = None
     enabled: bool = False
 
     def copy(self, **kwargs):
@@ -28,6 +29,8 @@ class Binding:
 
 
 class InputMode:
+    NO_KEY = False
+
     _registry = {}
 
     # global for all modes
@@ -81,7 +84,7 @@ class InputMode:
         cls._extensions.append(mode_type)
 
     @classmethod
-    def bind(cls, label, action, helptext=None, keysym=None, menupath=None):
+    def bind(cls, label, action, helptext=None, keysym=None, menupath=None, selected=None):
         """
         binding at the class level lets us know what the mode's
         bindings are before we create an instance of it
@@ -91,8 +94,11 @@ class InputMode:
                 "default", action, helptext, InputMode._num_bindings, None, None, cls
             )
         else:
+            if keysym == cls.NO_KEY:
+                keysym = f"__{len(cls._bindings)}"
+
             binding = Binding(
-                label, action, helptext, InputMode._num_bindings, keysym, menupath, cls
+                label, action, helptext, InputMode._num_bindings, keysym, menupath, cls, selected
             )
             cls._bindings[keysym] = binding
             InputMode._bindings_by_label[label] = binding

--- a/mfp/gui/modes/global_mode.py
+++ b/mfp/gui/modes/global_mode.py
@@ -296,6 +296,42 @@ class GlobalMode (InputMode):
                 "tile-control", cls.tile_manager_prefix,
                 keysym="C-a"
             )
+            cls.bind(
+                "app-scale-100",
+                lambda mode: mode.set_app_scale(1.0),
+                menupath="Window > DPI Scale > []100%",
+                keysym=cls.NO_KEY,
+                selected=lambda: MFPGUI().appwin.imgui_global_scale == 1.0
+            )
+            cls.bind(
+                "app-scale-125", lambda mode: mode.set_app_scale(1.25),
+                keysym=cls.NO_KEY,
+                menupath="Window > DPI Scale > []125%",
+                selected=lambda: MFPGUI().appwin.imgui_global_scale == 1.25
+            )
+            cls.bind(
+                "app-scale-150", lambda mode: mode.set_app_scale(1.50),
+                keysym=cls.NO_KEY,
+                menupath="Window > DPI Scale > []150%",
+                selected=lambda: MFPGUI().appwin.imgui_global_scale == 1.50
+            )
+            cls.bind(
+                "app-scale-200", lambda mode: mode.set_app_scale(2.0),
+                keysym=cls.NO_KEY,
+                menupath="Window > DPI Scale > []200%",
+                selected=lambda: MFPGUI().appwin.imgui_global_scale == 2.0
+            )
+            cls.bind(
+                "app-scale-250", lambda mode: mode.set_app_scale(2.5),
+                keysym=cls.NO_KEY,
+                menupath="Window > DPI Scale > []250%",
+                selected=lambda: MFPGUI().appwin.imgui_global_scale == 2.5
+            )
+
+
+    def set_app_scale(self, scale_factor):
+        self.window.imgui_global_scale = scale_factor
+        return True
 
     async def toggle_panel_mode(self):
         patch = self.window.selected_patch

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cffi==1.17.1
 Cython==3.0.12
 flopsy==0.0.7
 glfw==2.8.0
-imgui-bundle==1.6.3
+imgui-bundle==1.92.0
 munch==4.0.0
 numpy==2.2.4
 pillow==11.1.0


### PR DESCRIPTION
ImGui 1.92 introduces much better font scaling support and has breaking changes. I think this is a good opportunity to implment #313 while porting.

TODO:
- [ ] Audit all padding and `imgui.dummy()` spacers and globally scale where needed
- [ ] Check for scalability of `tt` font in markdown (should just work?)
- [ ] Automatically scale canvas zoom to match imgui scaling factor
- [ ] Resize window proportionaltely to the change in scaling factor